### PR TITLE
Create coworking reservation demo application

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.DS_Store
+dist
+npm-debug.log*
+.yarn*
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
-# cowork-reservations
+# 大学コワーキング施設 利用登録デモ
+
+大学内コワーキング施設（定員3名）の予約・利用状況をブラウザローカルで管理する React + Vite 製デモアプリです。外部サーバーや認証を伴わず、`localStorage` のみでデータを永続化します。
+
+## 主な機能
+
+- 月/週/日ビューを切り替えられる 30 分刻みのカレンダー
+- スロットごとの在室人数バッジ表示（満席アラートあり）
+- 匿名化された予約詳細ポップオーバーと直近予約の編集・削除
+- 氏名・所属・利用時間を入力する予約作成/編集ダイアログ
+- 予約データの JSON エクスポート/インポートと全件削除
+- Asia/Tokyo タイムゾーンに合わせた日付計算
+
+## 技術スタック
+
+- [React](https://react.dev/)
+- [Vite](https://vitejs.dev/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [dayjs](https://day.js.org/)
+- [tweakcn](https://github.com/jnsahaj/tweakcn)
+
+## 開発手順
+
+> **注意:** このリポジトリはデモ環境向けに作成されており、`npm install` が制限される場合があります。
+
+1. 依存パッケージをインストール
+
+   ```bash
+   npm install
+   ```
+
+2. 開発サーバーを起動
+
+   ```bash
+   npm run dev
+   ```
+
+3. ビルド（GitHub Pages などで配信する場合）
+
+   ```bash
+   npm run build
+   ```
+
+4. ビルド成果物のプレビュー
+
+   ```bash
+   npm run preview
+   ```
+
+## データ仕様
+
+`localStorage` の `cowork-reservations` キーに以下の形式で保存されます。
+
+```json
+{
+  "version": 1,
+  "data": [
+    {
+      "id": "uuid",
+      "name": "氏名",
+      "affiliation": "所属",
+      "start": "2025-09-26T10:00:00+09:00",
+      "end": "2025-09-26T11:30:00+09:00",
+      "createdAt": "2025-09-26T09:10:00+09:00",
+      "updatedAt": "2025-09-26T09:10:00+09:00"
+    }
+  ]
+}
+```
+
+## ライセンス
+
+このリポジトリはデモ用途のため、特にライセンスを定めていません。必要に応じて適宜追記してください。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja" data-theme="system">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>大学コワーキング施設 利用登録デモ</title>
+  </head>
+  <body class="bg-base-200 text-base-content">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "cowork-reservations",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview --port 4173",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "dayjs": "^1.11.11",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tweakcn": "^0.3.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.26",
+    "@types/react-dom": "^18.2.11",
+    "@typescript-eslint/eslint-plugin": "^6.10.0",
+    "@typescript-eslint/parser": "^6.10.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.53.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "typescript": "^5.2.2",
+    "uuid": "^9.0.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="410" height="404" viewBox="0 0 410 404" fill="none">
+  <path d="M399.641 59.5245L216.414 388.545C211.748 396.793 200.262 396.851 195.508 388.648L10.5817 59.5563C5.38074 50.5314 12.3975 39.3266 22.6091 39.3266H387.273C397.424 39.3266 404.45 50.3698 399.397 59.4549L399.641 59.5245Z" fill="url(#paint0_linear_2_3)"/>
+  <path d="M292.965 1.5744L156.679 275.391C154.158 280.514 147.055 280.548 144.474 275.454L86.2662 157.939C83.7471 152.975 87.3586 147.133 92.9229 147.133H166.004C168.698 147.133 170.91 145.238 171.224 142.57L178.9 76.8645C179.215 74.194 181.428 72.2996 184.123 72.2996H285.148C290.687 72.2996 294.273 78.2564 291.827 83.2153L266.488 133.678C265.047 136.575 267.181 140 270.422 140H310.297C316.029 140 319.621 146.356 316.93 151.311Z" fill="url(#paint1_linear_2_3)"/>
+  <defs>
+    <linearGradient id="paint0_linear_2_3" x1="6.00017" y1="32.9999" x2="235" y2="344" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#41D1FF"/>
+      <stop offset="1" stop-color="#BD34FE"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear_2_3" x1="24.1189" y1="-0.461121" x2="184.193" y2="266.814" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFEA83"/>
+      <stop offset="0.0833333" stop-color="#FFDD35"/>
+      <stop offset="1" stop-color="#FFA800"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,275 @@
+import { useRef, useState } from 'react';
+import dayjs from 'dayjs';
+import { Calendar, SlotClickPayload } from './components/Calendar';
+import { ReservationDialog, ReservationFormValues } from './components/ReservationDialog';
+import { SlotDetailsPopover } from './components/SlotDetailsPopover';
+import { ToastContainer } from './components/ToastContainer';
+import { useReservations } from './hooks/useReservations';
+import { useToasts } from './hooks/useToasts';
+import { clearReservations, exportReservations, importReservations } from './services/storage';
+import { Reservation, ViewMode } from './types';
+import { getSlotEnd, toDayjs, withinEditableWindow } from './services/availability';
+
+const initialStart = dayjs().minute(Math.floor(dayjs().minute() / 30) * 30).second(0).millisecond(0);
+const INITIAL_FORM_VALUES: ReservationFormValues = {
+  name: '',
+  affiliation: '',
+  start: initialStart.toISOString(),
+  end: getSlotEnd(initialStart).toISOString()
+};
+
+type SlotDetailState = SlotClickPayload | null;
+
+type DialogState = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  values: ReservationFormValues;
+  target?: Reservation;
+  allowEditing: boolean;
+};
+
+export default function App() {
+  const { reservations, createReservation, updateReservation, deleteReservation, replaceReservations, stats } =
+    useReservations();
+  const { toasts, pushToast, dismissToast } = useToasts();
+  const [view, setView] = useState<ViewMode>('week');
+  const [anchorDate, setAnchorDate] = useState(dayjs());
+  const [slotDetail, setSlotDetail] = useState<SlotDetailState>(null);
+  const [dialogState, setDialogState] = useState<DialogState>({
+    open: false,
+    mode: 'create',
+    values: INITIAL_FORM_VALUES,
+    allowEditing: true
+  });
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const closeDialog = () => setDialogState((prev) => ({ ...prev, open: false }));
+
+  const handleAnchorDateChange = (next: dayjs.Dayjs) => {
+    setAnchorDate(next);
+    setSlotDetail(null);
+  };
+
+  const handleViewChange = (next: ViewMode) => {
+    setView(next);
+    setSlotDetail(null);
+  };
+
+  const openCreateDialog = (startIso: string, endIso: string) => {
+    setDialogState({
+      open: true,
+      mode: 'create',
+      values: {
+        name: '',
+        affiliation: '',
+        start: startIso,
+        end: endIso
+      },
+      allowEditing: true
+    });
+  };
+
+  const openEditDialog = (reservation: Reservation) => {
+    setDialogState({
+      open: true,
+      mode: 'edit',
+      values: {
+        name: reservation.name,
+        affiliation: reservation.affiliation,
+        start: reservation.start,
+        end: reservation.end
+      },
+      target: reservation,
+      allowEditing: withinEditableWindow(reservation)
+    });
+  };
+
+  const handleSlotClick = (payload: SlotClickPayload) => {
+    setSlotDetail(payload);
+  };
+
+  const handleCreateFromDay = (day: dayjs.Dayjs) => {
+    handleAnchorDateChange(day);
+    handleViewChange('day');
+    const start = day.hour(9).minute(0).second(0).millisecond(0);
+    openCreateDialog(start.toISOString(), getSlotEnd(start).toISOString());
+  };
+
+  const handleDialogSubmit = (values: ReservationFormValues) => {
+    if (dialogState.mode === 'create') {
+      const { reservation, error } = createReservation(values);
+      if (error) {
+        pushToast({ title: '予約に失敗しました', description: error.message, intent: 'error' });
+        return { ok: false, error: error.message };
+      }
+      if (reservation) {
+        pushToast({ title: '予約を保存しました', intent: 'success' });
+      }
+      return { ok: true };
+    }
+
+    if (dialogState.mode === 'edit' && dialogState.target) {
+      const { reservation, error } = updateReservation({ id: dialogState.target.id, changes: values });
+      if (error) {
+        pushToast({ title: '更新に失敗しました', description: error.message, intent: 'error' });
+        return { ok: false, error: error.message };
+      }
+      if (reservation) {
+        pushToast({ title: '予約を更新しました', intent: 'success' });
+      }
+      return { ok: true };
+    }
+
+    return { ok: false, error: '操作を完了できませんでした。' };
+  };
+
+  const handleDeleteReservation = (reservation: Reservation) => {
+    if (!withinEditableWindow(reservation)) {
+      pushToast({ title: '削除できません', description: '編集可能な時間を過ぎています。', intent: 'error' });
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm('この予約を削除しますか？');
+      if (!confirmed) return;
+    }
+    deleteReservation(reservation.id);
+    pushToast({ title: '予約を削除しました', intent: 'success' });
+    setSlotDetail(null);
+  };
+
+  const handleExport = () => {
+    try {
+      exportReservations(reservations);
+      pushToast({ title: 'JSONをエクスポートしました', intent: 'success' });
+    } catch (error) {
+      pushToast({ title: 'エクスポートに失敗しました', description: String(error), intent: 'error' });
+    }
+  };
+
+  const handleImport = async (file: File) => {
+    try {
+      const imported = await importReservations(file);
+      replaceReservations(imported);
+      setSlotDetail(null);
+      pushToast({ title: 'データをインポートしました', intent: 'success' });
+    } catch (error) {
+      pushToast({ title: 'インポートに失敗しました', description: String(error), intent: 'error' });
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleClear = () => {
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm('全ての予約データを削除しますか？');
+      if (!confirmed) return;
+    }
+    clearReservations();
+    replaceReservations([]);
+    setSlotDetail(null);
+    pushToast({ title: '全データを削除しました', intent: 'success' });
+  };
+
+  const latestCreatedText = stats.latestCreatedAt ? toDayjs(stats.latestCreatedAt).format('M/D HH:mm') : 'なし';
+
+  return (
+    <div className="twc-app">
+      <header className="px-6 py-4 border-b border-neutral-200/60 bg-base-100 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">大学コワーキング施設 利用登録デモ</h1>
+          <p className="text-sm text-neutral-500">ブラウザローカルで動作する予約・状況可視化ツール</p>
+        </div>
+        <div className="hidden sm:flex items-center gap-2">
+          <span className="badge badge-soft">最大3名 / 30分刻み</span>
+          <span className="badge badge-soft">匿名表示</span>
+        </div>
+      </header>
+
+      <main className="twc-main">
+        <Calendar
+          reservations={reservations}
+          view={view}
+          anchorDate={anchorDate}
+          onAnchorDateChange={handleAnchorDateChange}
+          onViewChange={handleViewChange}
+          onSlotClick={handleSlotClick}
+          onCreateFromDay={handleCreateFromDay}
+        />
+
+        {slotDetail ? (
+          <SlotDetailsPopover
+            slotStartIso={slotDetail.slotStart}
+            anchor={slotDetail.anchor}
+            reservations={reservations}
+            onClose={() => setSlotDetail(null)}
+            onCreate={(startIso, endIso) => {
+              openCreateDialog(startIso, endIso);
+              setSlotDetail(null);
+            }}
+            onEdit={(reservation) => {
+              openEditDialog(reservation);
+              setSlotDetail(null);
+            }}
+            onDelete={handleDeleteReservation}
+          />
+        ) : null}
+
+        <section className="twc-data-card" aria-label="データ管理">
+          <header className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">データ管理</h2>
+              <p className="text-sm text-neutral-500">JSONエクスポート / インポート・全削除</p>
+            </div>
+            <span className="text-xs text-neutral-400">最新作成: {latestCreatedText}</span>
+          </header>
+          <div className="twc-data-actions">
+            <button type="button" className="btn btn-sm btn-primary" onClick={handleExport}>
+              エクスポート
+            </button>
+            <label className="btn btn-sm btn-outline twc-file-input">
+              インポート
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json"
+                hidden
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    void handleImport(file);
+                  }
+                }}
+              />
+            </label>
+            <button type="button" className="btn btn-sm btn-ghost text-error" onClick={handleClear}>
+              全削除
+            </button>
+          </div>
+        </section>
+      </main>
+
+      <ReservationDialog
+        open={dialogState.open}
+        mode={dialogState.mode}
+        values={dialogState.values}
+        onClose={() => {
+          closeDialog();
+        }}
+        onSubmit={handleDialogSubmit}
+        onDelete={
+          dialogState.target
+            ? () => {
+                handleDeleteReservation(dialogState.target as Reservation);
+                closeDialog();
+              }
+            : undefined
+        }
+        allowEditing={dialogState.allowEditing}
+      />
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  );
+}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,249 @@
+import { Fragment, useMemo } from 'react';
+import type { MouseEvent } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { Reservation, ViewMode } from '../types';
+import {
+  getMonthGrid,
+  getWeekRange,
+  getTimeLabels,
+  summarizeOccupancy,
+  getSlotEnd,
+  SLOT_MINUTES,
+  toDayjs
+} from '../services/availability';
+
+const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+export type SlotClickPayload = {
+  slotStart: string;
+  anchor: { top: number; left: number; width: number; height: number };
+};
+
+type CalendarProps = {
+  reservations: Reservation[];
+  view: ViewMode;
+  anchorDate: Dayjs;
+  onAnchorDateChange: (next: Dayjs) => void;
+  onViewChange: (view: ViewMode) => void;
+  onSlotClick: (payload: SlotClickPayload) => void;
+  onCreateFromDay: (day: Dayjs) => void;
+};
+
+export function Calendar({
+  reservations,
+  view,
+  anchorDate,
+  onAnchorDateChange,
+  onViewChange,
+  onSlotClick,
+  onCreateFromDay
+}: CalendarProps) {
+  const title = useMemo(() => {
+    if (view === 'month') {
+      return anchorDate.format('YYYY年 M月');
+    }
+    if (view === 'week') {
+      const { start, end } = getWeekRange(anchorDate);
+      return `${start.format('YYYY年M月D日')}〜${end.subtract(1, 'day').format('M月D日')}`;
+    }
+    return anchorDate.format('YYYY年M月D日 (ddd)');
+  }, [anchorDate, view]);
+
+  const goToToday = () => onAnchorDateChange(dayjs());
+  const goPrevious = () => {
+    if (view === 'month') {
+      onAnchorDateChange(anchorDate.subtract(1, 'month'));
+    } else if (view === 'week') {
+      onAnchorDateChange(anchorDate.subtract(1, 'week'));
+    } else {
+      onAnchorDateChange(anchorDate.subtract(1, 'day'));
+    }
+  };
+
+  const goNext = () => {
+    if (view === 'month') {
+      onAnchorDateChange(anchorDate.add(1, 'month'));
+    } else if (view === 'week') {
+      onAnchorDateChange(anchorDate.add(1, 'week'));
+    } else {
+      onAnchorDateChange(anchorDate.add(1, 'day'));
+    }
+  };
+
+  return (
+    <div className="twc-scroll-container" aria-label="予約カレンダー">
+      <div className="p-4 sm:p-6 space-y-4">
+        <header className="twc-toolbar" aria-label="カレンダーナビゲーション">
+          <div className="twc-toolbar-group" role="group" aria-label="表示期間移動">
+            <button type="button" className="btn btn-sm btn-ghost" onClick={goPrevious}>
+              ←
+            </button>
+            <button type="button" className="btn btn-sm btn-ghost" onClick={goToToday}>
+              今日
+            </button>
+            <button type="button" className="btn btn-sm btn-ghost" onClick={goNext}>
+              →
+            </button>
+          </div>
+          <h2 className="text-lg font-semibold flex-1">{title}</h2>
+          <div className="twc-toolbar-group" role="tablist" aria-label="ビュー切替">
+            {(
+              [
+                { label: '月', value: 'month' },
+                { label: '週', value: 'week' },
+                { label: '日', value: 'day' }
+              ] satisfies { label: string; value: ViewMode }[]
+            ).map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                role="tab"
+                aria-selected={view === item.value}
+                className={`btn btn-sm btn-ghost ${view === item.value ? 'twc-active' : ''}`}
+                onClick={() => onViewChange(item.value)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {view === 'month' ? (
+          <MonthView reservations={reservations} anchorDate={anchorDate} onSelectDay={onCreateFromDay} />
+        ) : (
+          <WeekDayView
+            reservations={reservations}
+            anchorDate={anchorDate}
+            view={view}
+            onSlotClick={onSlotClick}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+type MonthViewProps = {
+  reservations: Reservation[];
+  anchorDate: Dayjs;
+  onSelectDay: (day: Dayjs) => void;
+};
+
+function MonthView({ reservations, anchorDate, onSelectDay }: MonthViewProps) {
+  const days = useMemo(() => getMonthGrid(anchorDate), [anchorDate]);
+
+  return (
+    <div className="twc-month-grid">
+      {days.map((day) => {
+        const dayReservations = reservations.filter((reservation) => toDayjs(reservation.start).isSame(day, 'day'));
+        const total = dayReservations.length;
+        const occupancyMap = new Map<string, number>();
+        dayReservations.forEach((reservation) => {
+          const start = toDayjs(reservation.start);
+          const end = toDayjs(reservation.end);
+          for (let cursor = start; cursor.isBefore(end); cursor = cursor.add(SLOT_MINUTES, 'minute')) {
+            const key = cursor.format();
+            const current = occupancyMap.get(key) ?? 0;
+            occupancyMap.set(key, current + 1);
+          }
+        });
+        const peak = Math.max(0, ...Array.from(occupancyMap.values()));
+        const isCurrentMonth = day.isSame(anchorDate, 'month');
+
+        return (
+          <button
+            type="button"
+            key={day.toISOString()}
+            className={`twc-day-cell text-left ${isCurrentMonth ? '' : 'opacity-60'}`}
+            onClick={() => onSelectDay(day)}
+          >
+            <div className="twc-day-cell-header">
+              <span>{day.format('D日')}</span>
+              {peak >= 3 ? <span className="twc-slot-badge twc-full">満席多数</span> : null}
+            </div>
+            <div className="twc-day-cell-body">
+              <span>{total === 0 ? '予約なし' : `予約 ${total} 件`}</span>
+              <span>最大同時利用 {peak}/3</span>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+type WeekDayViewProps = {
+  reservations: Reservation[];
+  anchorDate: Dayjs;
+  view: Extract<ViewMode, 'week' | 'day'>;
+  onSlotClick: (payload: SlotClickPayload) => void;
+};
+
+function WeekDayView({ reservations, anchorDate, view, onSlotClick }: WeekDayViewProps) {
+  const { days, labels } = useMemo(() => {
+    const timeLabels = getTimeLabels();
+    if (view === 'day') {
+      return { days: [anchorDate.startOf('day')], labels: timeLabels };
+    }
+    const { start } = getWeekRange(anchorDate);
+    return {
+      days: Array.from({ length: 7 }, (_, index) => start.add(index, 'day')),
+      labels: timeLabels
+    };
+  }, [anchorDate, view]);
+
+  const handleSlotClick = (
+    event: MouseEvent<HTMLButtonElement>,
+    day: Dayjs,
+    label: string
+  ) => {
+    const slotStart = day.hour(Number(label.split(':')[0])).minute(Number(label.split(':')[1]));
+    const anchor = event.currentTarget.getBoundingClientRect();
+    const top = anchor.top + (typeof window !== 'undefined' ? window.scrollY : 0);
+    const left = anchor.left + (typeof window !== 'undefined' ? window.scrollX : 0);
+    onSlotClick({
+      slotStart: slotStart.toISOString(),
+      anchor: { top, left, width: anchor.width, height: anchor.height }
+    });
+  };
+
+  return (
+    <div className="twc-calendar-grid" style={{ gridTemplateColumns: `5rem repeat(${days.length}, minmax(0, 1fr))` }}>
+      <div />
+      {days.map((day) => (
+        <div key={day.toISOString()} className="p-2 text-sm font-semibold text-neutral-500">
+          {day.format('M/D')} ({WEEKDAY_LABELS[day.day()]})
+        </div>
+      ))}
+      {labels.map((label) => (
+        <Fragment key={label}>
+          <div className="twc-time-cell twc-time-label" aria-hidden>
+            {label}
+          </div>
+          {days.map((day) => {
+            const slotStart = day.hour(Number(label.split(':')[0])).minute(Number(label.split(':')[1]));
+            const occupancy = summarizeOccupancy(reservations, slotStart);
+            const slotEnd = getSlotEnd(slotStart);
+            const state = occupancy.count >= 3 ? 'twc-full' : occupancy.count >= 2 ? 'twc-limited' : 'twc-available';
+            return (
+              <button
+                key={`${day.toISOString()}-${label}`}
+                type="button"
+                className={`twc-time-cell ${state}`}
+                onClick={(event) => handleSlotClick(event, day, label)}
+                aria-label={`${day.format('M月D日')} ${label}〜${slotEnd.format('HH:mm')} の空き状況: ${
+                  occupancy.count
+                } / ${occupancy.max}`}
+              >
+                <span className={`twc-slot-badge ${state}`}>
+                  <span className="twc-badge-text">{occupancy.count}</span>
+                  <span className="text-xs text-neutral-400">/ {occupancy.max}</span>
+                </span>
+              </button>
+            );
+          })}
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ReservationDialog.tsx
+++ b/src/components/ReservationDialog.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import { validateRange, toDayjs } from '../services/availability';
+
+export type ReservationFormValues = {
+  name: string;
+  affiliation: string;
+  start: string;
+  end: string;
+};
+
+type ReservationDialogProps = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  values: ReservationFormValues;
+  onClose: () => void;
+  onSubmit: (values: ReservationFormValues) => { ok: boolean; error?: string };
+  onDelete?: () => void;
+  allowEditing?: boolean;
+};
+
+export function ReservationDialog({
+  open,
+  mode,
+  values,
+  onClose,
+  onSubmit,
+  onDelete,
+  allowEditing = true
+}: ReservationDialogProps) {
+  const [formValues, setFormValues] = useState(values);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (open) {
+      setFormValues(values);
+      setErrors({});
+    }
+  }, [open, values]);
+
+  const isCreate = mode === 'create';
+
+  const periodText = useMemo(() => {
+    const start = toDayjs(formValues.start);
+    const end = toDayjs(formValues.end);
+    return `${start.format('M月D日 HH:mm')} 〜 ${end.format('HH:mm')}`;
+  }, [formValues.start, formValues.end]);
+
+  if (!open) return null;
+
+  const handleChange = (field: keyof ReservationFormValues, value: string) => {
+    setFormValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const validate = (): boolean => {
+    const nextErrors: Record<string, string> = {};
+    if (!formValues.name.trim()) {
+      nextErrors.name = '氏名は必須です。';
+    }
+    if (!formValues.affiliation.trim()) {
+      nextErrors.affiliation = '所属は必須です。';
+    }
+    const start = dayjs(formValues.start);
+    const end = dayjs(formValues.end);
+    const rangeError = validateRange(start, end);
+    if (rangeError) {
+      nextErrors.time = rangeError;
+    }
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!validate()) return;
+    const result = onSubmit(formValues);
+    if (!result.ok) {
+      setErrors((prev) => ({ ...prev, submit: result.error ?? '保存に失敗しました。' }));
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <div className="twc-dialog-backdrop" role="dialog" aria-modal="true">
+      <form className="twc-dialog" onSubmit={handleSubmit}>
+        <div className="twc-dialog-header">
+          <div>
+            <h2 className="text-xl font-semibold">
+              {isCreate ? '新規予約' : allowEditing ? '予約の編集' : '予約の閲覧'}
+            </h2>
+            <p className="text-sm text-neutral-500 mt-1">{periodText}</p>
+            {!allowEditing ? (
+              <p className="text-xs text-neutral-400 mt-1">作成から10分を超えているため編集できません。</p>
+            ) : null}
+          </div>
+          <button type="button" className="btn btn-sm btn-ghost" onClick={onClose} aria-label="閉じる">
+            ✕
+          </button>
+        </div>
+
+        <div className="twc-input-grid">
+          <div className="twc-form-field">
+            <label className="text-sm font-medium" htmlFor="reservation-name">
+              氏名
+            </label>
+            <input
+              id="reservation-name"
+              type="text"
+              className="input input-bordered"
+              value={formValues.name}
+              onChange={(event) => handleChange('name', event.target.value)}
+              required
+              disabled={!allowEditing}
+            />
+            {errors.name ? <p className="twc-error-text">{errors.name}</p> : null}
+          </div>
+
+          <div className="twc-form-field">
+            <label className="text-sm font-medium" htmlFor="reservation-affiliation">
+              所属
+            </label>
+            <input
+              id="reservation-affiliation"
+              type="text"
+              className="input input-bordered"
+              value={formValues.affiliation}
+              onChange={(event) => handleChange('affiliation', event.target.value)}
+              required
+              disabled={!allowEditing}
+            />
+            {errors.affiliation ? <p className="twc-error-text">{errors.affiliation}</p> : null}
+          </div>
+
+          <div className="twc-form-field">
+            <label className="text-sm font-medium" htmlFor="reservation-start">
+              開始
+            </label>
+            <input
+              id="reservation-start"
+              type="datetime-local"
+              className="input input-bordered"
+              value={formatForInput(formValues.start)}
+              onChange={(event) => handleChange('start', dayjs(event.target.value).toISOString())}
+              step={SLOT_STEP_SECONDS}
+              required
+              disabled={!allowEditing}
+            />
+          </div>
+
+          <div className="twc-form-field">
+            <label className="text-sm font-medium" htmlFor="reservation-end">
+              終了
+            </label>
+            <input
+              id="reservation-end"
+              type="datetime-local"
+              className="input input-bordered"
+              value={formatForInput(formValues.end)}
+              onChange={(event) => handleChange('end', dayjs(event.target.value).toISOString())}
+              step={SLOT_STEP_SECONDS}
+              required
+              disabled={!allowEditing}
+            />
+          </div>
+
+          {errors.time ? <p className="twc-error-text">{errors.time}</p> : null}
+          {errors.submit ? <p className="twc-error-text">{errors.submit}</p> : null}
+        </div>
+
+        <div className="twc-dialog-footer">
+          {!isCreate && onDelete ? (
+            <button
+              type="button"
+              className="btn btn-outline btn-error mr-auto"
+              onClick={onDelete}
+              disabled={!allowEditing}
+            >
+              削除
+            </button>
+          ) : null}
+          <button type="button" className="btn btn-ghost" onClick={onClose}>
+            キャンセル
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={!allowEditing}>
+            {isCreate ? '予約する' : '更新する'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+const SLOT_STEP_SECONDS = 30 * 60;
+
+function formatForInput(value: string): string {
+  return dayjs(value).format('YYYY-MM-DDTHH:mm');
+}

--- a/src/components/SlotDetailsPopover.tsx
+++ b/src/components/SlotDetailsPopover.tsx
@@ -1,0 +1,122 @@
+import dayjs from 'dayjs';
+import type { CSSProperties } from 'react';
+import { Reservation } from '../types';
+import { getSlotEnd, summarizeOccupancy, toDayjs, withinEditableWindow } from '../services/availability';
+
+type SlotDetailsPopoverProps = {
+  slotStartIso: string;
+  anchor: { top: number; left: number; width: number; height: number };
+  reservations: Reservation[];
+  onClose: () => void;
+  onCreate: (startIso: string, endIso: string) => void;
+  onEdit: (reservation: Reservation) => void;
+  onDelete: (reservation: Reservation) => void;
+};
+
+export function SlotDetailsPopover({
+  slotStartIso,
+  anchor,
+  reservations,
+  onClose,
+  onCreate,
+  onEdit,
+  onDelete
+}: SlotDetailsPopoverProps) {
+  const slotStart = dayjs(slotStartIso);
+  const slotEnd = getSlotEnd(slotStart);
+  const occupancy = summarizeOccupancy(reservations, slotStart);
+  const overlappingReservations = reservations
+    .filter((reservation) => {
+      const start = toDayjs(reservation.start);
+      const end = toDayjs(reservation.end);
+      return start.isBefore(slotEnd) && slotStart.isBefore(end);
+    })
+    .sort((a, b) => toDayjs(a.start).valueOf() - toDayjs(b.start).valueOf());
+
+  const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
+  const left = Math.max(16, Math.min(anchor.left, viewportWidth - 320));
+  const style: CSSProperties = {
+    position: 'fixed',
+    top: anchor.top + anchor.height + 8,
+    left,
+    zIndex: 30
+  };
+
+  const createReservation = () => onCreate(slotStartIso, slotEnd.toISOString());
+
+  return (
+    <div className="twc-popover" style={style} role="dialog" aria-modal="false">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-xs text-neutral-400">{slotStart.format('M月D日 (ddd)')}</p>
+          <h3 className="font-semibold">{slotStart.format('HH:mm')}〜{slotEnd.format('HH:mm')}</h3>
+        </div>
+        <button type="button" className="btn btn-xs btn-ghost" aria-label="閉じる" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+
+      <div className="twc-availability-grid mt-3">
+        <div className="twc-availability-card">
+          <span className="text-xs text-neutral-500">現在の利用状況</span>
+          <span className="text-lg font-semibold">{occupancy.count} / {occupancy.max}</span>
+          <span className="text-xs text-neutral-500">同時定員 3 名</span>
+        </div>
+      </div>
+
+      <button type="button" className="btn btn-sm btn-primary w-full mt-3" onClick={createReservation}>
+        この時間で予約する
+      </button>
+
+      <div className="mt-4 space-y-2" aria-live="polite">
+        <p className="text-xs text-neutral-500">重なっている予約 ({overlappingReservations.length} 件)</p>
+        {overlappingReservations.length === 0 ? (
+          <p className="text-sm">この時間帯の予約はありません。</p>
+        ) : (
+          <ul className="space-y-2">
+            {overlappingReservations.map((reservation) => {
+              const start = toDayjs(reservation.start);
+              const end = toDayjs(reservation.end);
+              const editable = withinEditableWindow(reservation);
+              return (
+                <li key={reservation.id} className="p-2 rounded-lg bg-neutral-100/60">
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-medium">
+                        {start.format('HH:mm')}〜{end.format('HH:mm')}
+                      </p>
+                      <p className="text-xs text-neutral-500">
+                        登録: {toDayjs(reservation.createdAt).format('M/D HH:mm')}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className="btn btn-xs btn-outline"
+                        onClick={() => onEdit(reservation)}
+                        disabled={!editable}
+                      >
+                        編集
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-xs btn-ghost text-error"
+                        onClick={() => onDelete(reservation)}
+                        disabled={!editable}
+                      >
+                        削除
+                      </button>
+                    </div>
+                  </div>
+                  {!editable ? (
+                    <p className="text-[10px] text-neutral-400 mt-1">編集可能期限を過ぎています。</p>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,0 +1,33 @@
+import { Toast } from '../types';
+
+type ToastContainerProps = {
+  toasts: Toast[];
+  onDismiss: (id: string) => void;
+};
+
+export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="twc-toast-container" role="status" aria-live="polite">
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`twc-toast twc-${toast.intent}`}>
+          <div>
+            <div className="font-semibold text-sm">{toast.title}</div>
+            {toast.description ? (
+              <p className="text-xs text-neutral-500 mt-1 leading-snug">{toast.description}</p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            className="btn btn-sm btn-ghost"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="閉じる"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useReservations.ts
+++ b/src/hooks/useReservations.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import dayjs from 'dayjs';
+import { Reservation } from '../types';
+import { loadReservations, saveReservations } from '../services/storage';
+import { canCreateReservation, toDayjs } from '../services/availability';
+
+type CreateReservationInput = Omit<Reservation, 'id' | 'createdAt' | 'updatedAt'>;
+
+type UpdateReservationInput = {
+  id: string;
+  changes: Partial<Omit<Reservation, 'id' | 'createdAt'>>;
+};
+
+export type ReservationError = {
+  field?: keyof CreateReservationInput;
+  message: string;
+};
+
+export function useReservations() {
+  const [reservations, setReservations] = useState<Reservation[]>(() => loadReservations());
+
+  useEffect(() => {
+    saveReservations(reservations);
+  }, [reservations]);
+
+  const createReservation = useCallback(
+    (input: CreateReservationInput): { reservation?: Reservation; error?: ReservationError } => {
+      const now = dayjs().tz().toISOString();
+      const reservation: Reservation = {
+        id: uuid(),
+        createdAt: now,
+        updatedAt: now,
+        ...input
+      };
+
+      const capacity = canCreateReservation(reservation, reservations);
+      if (!capacity.ok) {
+        return { error: { message: capacity.reason ?? 'この時間帯は満席です。' } };
+      }
+
+      setReservations((prev) => [...prev, reservation]);
+      return { reservation };
+    },
+    [reservations]
+  );
+
+  const updateReservation = useCallback(
+    ({ id, changes }: UpdateReservationInput): { reservation?: Reservation; error?: ReservationError } => {
+      const existing = reservations.find((reservation) => reservation.id === id);
+      if (!existing) {
+        return { error: { message: '予約が見つかりませんでした。' } };
+      }
+
+      const updated: Reservation = {
+        ...existing,
+        ...changes,
+        updatedAt: dayjs().tz().toISOString()
+      };
+
+      const capacity = canCreateReservation(updated, reservations, { excludeId: id });
+      if (!capacity.ok) {
+        return { error: { message: capacity.reason ?? 'この時間帯は満席です。' } };
+      }
+
+      setReservations((prev) => prev.map((reservation) => (reservation.id === id ? updated : reservation)));
+      return { reservation: updated };
+    },
+    [reservations]
+  );
+
+  const deleteReservation = useCallback((id: string) => {
+    setReservations((prev) => prev.filter((reservation) => reservation.id !== id));
+  }, []);
+
+  const replaceReservations = useCallback((next: Reservation[]) => {
+    setReservations(next);
+  }, []);
+
+  const stats = useMemo(() => {
+    if (reservations.length === 0) return { latestCreatedAt: undefined as string | undefined };
+    const latest = reservations.reduce((latestReservation, current) => {
+      const currentDate = toDayjs(current.createdAt);
+      if (!latestReservation) return current;
+      const latestDate = toDayjs(latestReservation.createdAt);
+      return currentDate.isAfter(latestDate) ? current : latestReservation;
+    }, undefined as Reservation | undefined);
+    return {
+      latestCreatedAt: latest?.createdAt
+    };
+  }, [reservations]);
+
+  return {
+    reservations,
+    createReservation,
+    updateReservation,
+    deleteReservation,
+    replaceReservations,
+    stats
+  };
+}

--- a/src/hooks/useToasts.ts
+++ b/src/hooks/useToasts.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import { Toast } from '../types';
+
+export function useToasts() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const pushToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = uuid();
+    const nextToast: Toast = { id, ...toast };
+    setToasts((prev) => [...prev, nextToast]);
+    return id;
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  return {
+    toasts,
+    pushToast,
+    dismissToast
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import 'tweakcn/dist/tweakcn.css';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/services/availability.ts
+++ b/src/services/availability.ts
@@ -1,0 +1,145 @@
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { Reservation } from '../types';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(isSameOrAfter);
+dayjs.extend(isSameOrBefore);
+dayjs.tz.setDefault('Asia/Tokyo');
+
+export const SLOT_MINUTES = 30;
+const MAX_CAPACITY = 3;
+
+export function toDayjs(value: string | Dayjs): Dayjs {
+  return typeof value === 'string' ? dayjs(value).tz() : value.tz();
+}
+
+export function enumerateSlots(start: Dayjs, end: Dayjs, slotMinutes = SLOT_MINUTES): Dayjs[] {
+  const slots: Dayjs[] = [];
+  let cursor = start.startOf('minute');
+  const slotSize = slotMinutes;
+  while (cursor.isBefore(end)) {
+    slots.push(cursor);
+    cursor = cursor.add(slotSize, 'minute');
+  }
+  return slots;
+}
+
+export function reservationSlots(reservation: Reservation, slotMinutes = SLOT_MINUTES): Dayjs[] {
+  const start = toDayjs(reservation.start);
+  const end = toDayjs(reservation.end);
+  return enumerateSlots(start, end, slotMinutes);
+}
+
+export function overlaps(aStart: Dayjs, aEnd: Dayjs, bStart: Dayjs, bEnd: Dayjs): boolean {
+  return aStart.isBefore(bEnd) && bStart.isBefore(aEnd);
+}
+
+export function countOverlaps(reservations: Reservation[], slotStart: Dayjs, slotMinutes = SLOT_MINUTES): number {
+  const slotEnd = slotStart.add(slotMinutes, 'minute');
+  return reservations.reduce((count, reservation) => {
+    const resStart = toDayjs(reservation.start);
+    const resEnd = toDayjs(reservation.end);
+    if (overlaps(resStart, resEnd, slotStart, slotEnd)) {
+      return count + 1;
+    }
+    return count;
+  }, 0);
+}
+
+export type CapacityCheck = {
+  ok: boolean;
+  reason?: string;
+};
+
+export function canCreateReservation(
+  newReservation: Reservation,
+  reservations: Reservation[],
+  options?: { excludeId?: string }
+): CapacityCheck {
+  const filtered = options?.excludeId
+    ? reservations.filter((reservation) => reservation.id !== options.excludeId)
+    : reservations;
+
+  const newStart = toDayjs(newReservation.start);
+  const newEnd = toDayjs(newReservation.end);
+  const slots = enumerateSlots(newStart, newEnd);
+
+  for (const slot of slots) {
+    const existingCount = countOverlaps(filtered, slot);
+    const total = existingCount + 1;
+    if (total > MAX_CAPACITY) {
+      return {
+        ok: false,
+        reason: `この時間帯は満席です（${existingCount}/${MAX_CAPACITY}）。別の時間をご検討ください。`
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+export function isAlignedToSlot(value: Dayjs, slotMinutes = SLOT_MINUTES): boolean {
+  const minutes = value.minute();
+  return minutes % slotMinutes === 0 && value.second() === 0 && value.millisecond() === 0;
+}
+
+export function validateRange(start: Dayjs, end: Dayjs): string | undefined {
+  if (!start.isBefore(end)) {
+    return '終了時刻は開始時刻より後にしてください。';
+  }
+  if (!isAlignedToSlot(start) || !isAlignedToSlot(end)) {
+    return '開始・終了は30分刻みに揃えてください。';
+  }
+  return undefined;
+}
+
+export function summarizeOccupancy(
+  reservations: Reservation[],
+  slotStart: Dayjs,
+  slotMinutes = SLOT_MINUTES
+): { count: number; max: number } {
+  const count = countOverlaps(reservations, slotStart, slotMinutes);
+  return { count, max: MAX_CAPACITY };
+}
+
+export function getDayReservations(reservations: Reservation[], day: Dayjs): Reservation[] {
+  return reservations.filter((reservation) => {
+    const start = toDayjs(reservation.start);
+    return start.isSame(day, 'day');
+  });
+}
+
+export function getWeekRange(anchor: Dayjs): { start: Dayjs; end: Dayjs } {
+  const start = anchor.startOf('week');
+  const end = start.add(7, 'day');
+  return { start, end };
+}
+
+export function getMonthGrid(anchor: Dayjs): Dayjs[] {
+  const start = anchor.startOf('month').startOf('week');
+  return Array.from({ length: 42 }, (_, index) => start.add(index, 'day'));
+}
+
+export function getTimeLabels(slotMinutes = SLOT_MINUTES): string[] {
+  const start = dayjs().startOf('day');
+  const labels: string[] = [];
+  for (let m = 0; m < 24 * 60; m += slotMinutes) {
+    labels.push(start.add(m, 'minute').format('HH:mm'));
+  }
+  return labels;
+}
+
+export function getSlotEnd(slotStart: Dayjs, slotMinutes = SLOT_MINUTES): Dayjs {
+  return slotStart.add(slotMinutes, 'minute');
+}
+
+export function withinEditableWindow(reservation: Reservation, minutes = 10): boolean {
+  const created = toDayjs(reservation.createdAt);
+  const now = dayjs().tz();
+  return now.diff(created, 'minute') <= minutes;
+}

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,0 +1,74 @@
+import { Reservation, StorageShape } from '../types';
+
+const STORAGE_KEY = 'cowork-reservations';
+
+function safeWindow(): Window | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return window;
+}
+
+export function loadReservations(): Reservation[] {
+  const w = safeWindow();
+  if (!w) return [];
+  try {
+    const raw = w.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as StorageShape;
+    if (parsed.version !== 1 || !Array.isArray(parsed.data)) return [];
+    return parsed.data;
+  } catch (error) {
+    console.error('Failed to load reservations', error);
+    return [];
+  }
+}
+
+export function saveReservations(reservations: Reservation[]): void {
+  const w = safeWindow();
+  if (!w) return;
+  const payload: StorageShape = {
+    version: 1,
+    data: reservations
+  };
+  w.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function exportReservations(reservations: Reservation[]): void {
+  const payload: StorageShape = { version: 1, data: reservations };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const now = new Date();
+  const fileName = `cowork-reservations-${
+    now.getFullYear()
+  }${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}.json`;
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function importReservations(file: File): Promise<Reservation[]> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const result = typeof reader.result === 'string' ? reader.result : '';
+        const parsed = JSON.parse(result) as StorageShape;
+        if (parsed.version !== 1 || !Array.isArray(parsed.data)) {
+          throw new Error('フォーマットが不正です');
+        }
+        resolve(parsed.data);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('読み込みに失敗しました'));
+    reader.readAsText(file);
+  });
+}
+
+export function clearReservations(): void {
+  const w = safeWindow();
+  if (!w) return;
+  w.localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,316 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--twc-base-200, #f4f5f7);
+  color: var(--twc-base-content, #1f2937);
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.twc-app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.twc-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  gap: 1rem;
+  position: relative;
+}
+
+.twc-calendar-grid {
+  display: grid;
+  width: 100%;
+}
+
+.twc-scroll-container {
+  overflow: auto;
+  background: var(--twc-base-100, #ffffff);
+  border-radius: 1rem;
+  border: 1px solid var(--twc-neutral-200, rgba(15, 23, 42, 0.08));
+}
+
+.twc-time-cell {
+  position: relative;
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--twc-neutral-100, rgba(15, 23, 42, 0.06));
+  border-right: 1px solid var(--twc-neutral-100, rgba(15, 23, 42, 0.06));
+  cursor: pointer;
+  min-height: 3.5rem;
+  transition: background 0.15s ease;
+}
+
+.twc-time-cell:hover {
+  background: var(--twc-base-200, rgba(148, 163, 184, 0.15));
+}
+
+.twc-time-cell.twc-full {
+  background: rgba(239, 68, 68, 0.15);
+}
+
+.twc-time-cell.twc-limited {
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.twc-time-cell.twc-available {
+  background: transparent;
+}
+
+.twc-time-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--twc-neutral-400, #64748b);
+}
+
+.twc-slot-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.twc-slot-badge.twc-available {
+  background: rgba(56, 189, 248, 0.15);
+  color: #0369a1;
+}
+
+.twc-slot-badge.twc-limited {
+  background: rgba(245, 158, 11, 0.18);
+  color: #92400e;
+}
+
+.twc-slot-badge.twc-full {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.twc-badge-text {
+  font-variant-numeric: tabular-nums;
+}
+
+.twc-popover {
+  position: absolute;
+  inset: auto auto 0 0;
+  transform: translateY(100%);
+  margin-top: 0.5rem;
+  z-index: 20;
+  min-width: 16rem;
+  background: var(--twc-base-100, #fff);
+  border-radius: 0.75rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.75rem 1rem;
+}
+
+.twc-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+  padding: 1.5rem;
+}
+
+.twc-dialog {
+  background: var(--twc-base-100, #fff);
+  border-radius: 1.25rem;
+  width: min(32rem, 100%);
+  padding: 1.5rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  max-height: 90vh;
+  overflow: auto;
+}
+
+.twc-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.twc-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.twc-input-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.twc-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.twc-error-text {
+  color: #b91c1c;
+  font-size: 0.75rem;
+}
+
+.twc-toast-container {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 50;
+}
+
+.twc-toast {
+  background: var(--twc-base-100, #fff);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.twc-toast.twc-error {
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+.twc-toast.twc-success {
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.twc-toast button {
+  margin-left: auto;
+}
+
+.twc-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.twc-toolbar-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(148, 163, 184, 0.12);
+  padding: 0.25rem;
+  border-radius: 999px;
+}
+
+.twc-toolbar button {
+  border-radius: 999px;
+}
+
+.twc-toolbar .twc-active {
+  background: var(--twc-primary, #2563eb);
+  color: white;
+}
+
+.twc-month-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.twc-day-cell {
+  background: var(--twc-base-100, #fff);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 6rem;
+}
+
+.twc-day-cell-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.twc-day-cell-body {
+  font-size: 0.75rem;
+  color: var(--twc-neutral-500, #475569);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.twc-availability-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem;
+}
+
+.twc-availability-card {
+  background: rgba(226, 232, 240, 0.45);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.twc-data-card {
+  background: var(--twc-base-100, #fff);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.twc-data-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.twc-file-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .twc-time-cell {
+    min-height: 3rem;
+    padding: 0.5rem;
+  }
+
+  .twc-dialog {
+    width: 100%;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,25 @@
+export type ReservationId = string;
+
+export type Reservation = {
+  id: ReservationId;
+  name: string;
+  affiliation: string;
+  start: string; // ISO8601
+  end: string;   // ISO8601
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type StorageShape = {
+  version: 1;
+  data: Reservation[];
+};
+
+export type ViewMode = 'month' | 'week' | 'day';
+
+export type Toast = {
+  id: string;
+  title: string;
+  description?: string;
+  intent: 'success' | 'error' | 'info';
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/',
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript front-end that follows the coworking reservation demo specification, including calendar navigation and tweakcn styling
- implement reservation workflows with capacity checks, anonymized slot popovers, dialogs, and toast notifications
- add localStorage persistence plus JSON import/export and data clearing utilities for demo data management

## Testing
- Not run (npm install fails with 403 in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6406881fc8321b24f13d4d818d074